### PR TITLE
ci: temporarily disable Windows builds due to dependency conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # TEMPORARY: Windows excluded due to windows-sys dependency conflict in Nushell 0.109.1
+        # Issue: nu-protocol has incompatible windows-sys versions (0.60.2 vs 0.61.2)
+        # via miette->terminal_size and dirs-sys dependencies causing GUID type mismatch
+        # TODO: Re-enable Windows when Nushell 0.109.2+ is released with the fix
+        os: [ubuntu-latest, macos-latest]  # windows-latest temporarily removed
         rust: [stable, beta]
         include:
           - os: ubuntu-latest
             rust: 1.85.0  # MSRV for Rust edition 2024 support
         exclude:
-          - os: windows-latest
-            rust: beta
           - os: macos-latest
             rust: beta
 
@@ -156,7 +158,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # TEMPORARY: Windows excluded (see note in test job above)
+        os: [ubuntu-latest, macos-latest]
         
     steps:
     - name: Checkout code
@@ -201,10 +204,11 @@ jobs:
             target: aarch64-unknown-linux-gnu
             artifact_name: nu_plugin_nw_ulid
             asset_name: nu_plugin_nw_ulid-linux-aarch64
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            artifact_name: nu_plugin_nw_ulid.exe
-            asset_name: nu_plugin_nw_ulid-windows-x86_64.exe
+          # TEMPORARY: Windows build disabled (see note in test job above)
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+          #   artifact_name: nu_plugin_nw_ulid.exe
+          #   asset_name: nu_plugin_nw_ulid-windows-x86_64.exe
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: nu_plugin_nw_ulid


### PR DESCRIPTION
# Pull Request

## Description

Temporarily disables Windows builds in the CI pipeline due to a dependency conflict in Nushell 0.109.1. The conflict arises from incompatible `windows-sys` crate versions (0.60.2 vs 0.61.2) used by nu-protocol's transitive dependencies (miette→terminal_size and dirs-sys), causing GUID type mismatches that prevent compilation on Windows.

This is a temporary workaround until Nushell 0.109.2+ is released with the dependency fix.

## Type of Change

Please select the relevant option:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 📝 Script template (new template or example for common use cases)
- [x] 🔧 Maintenance (dependency updates, CI improvements, etc.)
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🏗️ Infrastructure (CI/CD, deployment, build improvements)

## Related Issues

Related to Nushell dependency conflict with windows-sys crate versions in nu-protocol 0.109.1

## Changes Made

Detailed list of changes to `.github/workflows/ci.yml`:

- Removed `windows-latest` from the test job matrix OS list
- Removed `windows-latest` from the clippy job matrix OS list
- Commented out the Windows release build configuration (x86_64-pc-windows-msvc target)
- Removed the `windows-latest` + `beta` rust exclusion rule (no longer needed since Windows is excluded entirely)
- Added detailed inline comments explaining the temporary exclusion and the underlying dependency conflict
- Added TODO comments to re-enable Windows builds when Nushell 0.109.2+ is available

## Testing

### Test Coverage

- [ ] New tests added for new functionality
- [ ] Existing tests updated as needed
- [x] All tests pass locally
- [x] Manual testing completed

### Testing Instructions

Reviewers can verify these changes by:

1. Reviewing the modified `.github/workflows/ci.yml` file to confirm Windows is properly excluded
2. Checking that the CI pipeline runs successfully without Windows builds
3. Verifying that Ubuntu and macOS builds continue to function correctly
4. Confirming that the comments adequately explain the temporary nature of this change

### Test Results

```bash
# CI will validate that:
# - Ubuntu and macOS tests continue to pass
# - Clippy linting works on remaining platforms
# - Release builds succeed for Linux and macOS targets
```

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement (provide benchmarks)
- [ ] Performance regression (justify why)
- [ ] Performance impact unknown/needs measurement

This change only affects CI build configuration and has no runtime performance impact.

## Security Considerations

- [x] No security implications
- [ ] Security improvement
- [ ] Potential security concern (describe below)

## Breaking Changes

This is not a breaking change for users. However, it temporarily removes Windows builds from the CI pipeline and release artifacts until the upstream dependency conflict is resolved.

## Documentation

- [x] Code comments updated
- [ ] README.md updated
- [ ] CHANGELOG.md updated
- [ ] API documentation updated
- [ ] Examples updated

Extensive inline comments have been added to the CI configuration explaining the reason for the temporary exclusion and when it should be reverted.

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] No new warnings introduced

### Testing & Validation

- [x] All tests pass (`cargo test`) - on supported platforms
- [x] No linting errors (`cargo clippy`) - on supported platforms
- [x] Code is properly formatted (`cargo fmt`)
- [x] Security audit passes (`cargo audit`)
- [x] Supply chain checks pass (`cargo deny check`)

### Documentation & Communication

- [x] Changes are documented
- [x] Commit messages follow conventional format
- [x] PR title is descriptive
- [ ] Any necessary migration guides created

### Dependencies & Compatibility

- [x] No unnecessary dependencies added
- [x] Minimum supported Rust version maintained
- [x] Nushell compatibility maintained
- [ ] Cross-platform compatibility verified - Windows temporarily disabled

## Additional Notes

This is a **temporary workaround** and should be reverted once Nushell releases version 0.109.2 or later with the windows-sys dependency conflict resolved. The CI configuration includes clear TODO comments marking where Windows should be re-enabled.

The underlying issue is in Nushell's dependency tree:
- `miette` → `terminal_size` → `windows-sys 0.60.2`
- `dirs-sys` → `windows-sys 0.61.2`

These conflicting versions cause GUID type mismatches during compilation on Windows. This only affects the build process and does not impact functionality on Linux or macOS.

**Action Required**: Monitor Nushell releases and re-enable Windows builds by reverting the changes in this PR once the dependency conflict is resolved upstream.