### PR TITLE
refactor(core): replace magic numbers with named constants for time conversions

### DIFF
--- a/src/commands/sort.rs
+++ b/src/commands/sort.rs
@@ -351,8 +351,8 @@ fn build_timestamp_value(
     span: nu_protocol::Span,
 ) -> Option<Value> {
     let timestamp_ms = components.timestamp_ms;
-    let timestamp_secs = timestamp_ms / 1000;
-    let timestamp_nanos = (timestamp_ms % 1000) * crate::NANOS_PER_MILLI;
+    let timestamp_secs = timestamp_ms / crate::MS_PER_SECOND;
+    let timestamp_nanos = (timestamp_ms % crate::MS_PER_SECOND) * crate::NANOS_PER_MILLI;
 
     let datetime = chrono::DateTime::from_timestamp(timestamp_secs as i64, timestamp_nanos as u32)?;
 

--- a/src/commands/stream.rs
+++ b/src/commands/stream.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
 
 use crate::{UlidEngine, UlidPlugin};
 
-const DEFAULT_BATCH_SIZE: usize = 1000;
+const DEFAULT_BATCH_SIZE: usize = 1_000;
 const MAX_STREAM_COUNT: usize = 100_000;
 
 /// Stream-processes large datasets of ULIDs with memory-efficient batching.

--- a/src/commands/time.rs
+++ b/src/commands/time.rs
@@ -219,7 +219,7 @@ impl PluginCommand for UlidTimeMillisCommand {
                     val
                 } else {
                     // Seconds, convert to milliseconds
-                    val * 1000
+                    val * crate::MS_PER_SECOND as i64
                 }
             }
             Some(Value::Float { val, .. }) => {
@@ -228,7 +228,7 @@ impl PluginCommand for UlidTimeMillisCommand {
                     val as i64
                 } else {
                     // Seconds, convert to milliseconds
-                    (val * 1000.0) as i64
+                    (val * crate::MS_PER_SECOND as f64) as i64
                 }
             }
             Some(_) => {
@@ -624,7 +624,7 @@ mod tests {
                 let result = if input > 1_000_000_000_000i64 {
                     input // Already milliseconds
                 } else {
-                    input * 1000 // Convert seconds to milliseconds
+                    input * crate::MS_PER_SECOND as i64 // Convert seconds to milliseconds
                 };
 
                 assert_eq!(result, expected, "Failed conversion for {}", description);
@@ -672,7 +672,7 @@ mod tests {
                 let result = if input > 1_000_000_000_000.0 {
                     input as i64 // Already milliseconds
                 } else {
-                    (input * 1000.0) as i64 // Convert seconds to milliseconds
+                    (input * crate::MS_PER_SECOND as f64) as i64 // Convert seconds to milliseconds
                 };
 
                 assert_eq!(
@@ -763,11 +763,11 @@ mod tests {
 
             for (timestamp_millis, description) in known_values {
                 // Test conversion to seconds
-                let seconds = timestamp_millis / 1000;
-                let reconstructed_millis = seconds * 1000;
+                let seconds = timestamp_millis / crate::MS_PER_SECOND as i64;
+                let reconstructed_millis = seconds * crate::MS_PER_SECOND as i64;
 
                 // Should be able to round-trip for exact seconds
-                if timestamp_millis % 1000 == 0 {
+                if timestamp_millis % crate::MS_PER_SECOND as i64 == 0 {
                     assert_eq!(
                         reconstructed_millis, timestamp_millis,
                         "Round-trip failed for {}",
@@ -1044,7 +1044,7 @@ mod tests {
                 let result = if input > 1_000_000_000_000i64 {
                     input // Already milliseconds  
                 } else {
-                    input * 1000 // Convert seconds
+                    input * crate::MS_PER_SECOND as i64 // Convert seconds
                 };
 
                 assert_eq!(result, expected, "Conversion failed for {}", description);
@@ -1065,7 +1065,7 @@ mod tests {
                 let result = if input > 1_000_000_000_000.0 {
                     input as i64 // Already milliseconds
                 } else {
-                    (input * 1000.0) as i64 // Convert seconds
+                    (input * crate::MS_PER_SECOND as f64) as i64 // Convert seconds
                 };
 
                 assert_eq!(

--- a/src/ulid_engine.rs
+++ b/src/ulid_engine.rs
@@ -18,6 +18,9 @@ pub const CROCKFORD_BASE32_CHARSET: &str = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 /// Nanoseconds per millisecond, used for timestamp conversions.
 pub const NANOS_PER_MILLI: u64 = 1_000_000;
 
+/// Milliseconds per second, used for timestamp conversions.
+pub const MS_PER_SECOND: u64 = 1_000;
+
 /// Bitmask for the 80-bit randomness component of a ULID.
 const ULID_RANDOMNESS_MASK: u128 = 0xFFFF_FFFF_FFFF_FFFF_FFFF;
 
@@ -205,8 +208,8 @@ impl UlidEngine {
         timestamp_record.push("ms", Value::int(components.timestamp_ms as i64, span));
 
         // Convert timestamp to ISO8601 format
-        let timestamp_secs = components.timestamp_ms / 1000;
-        let timestamp_nanos = (components.timestamp_ms % 1000) * NANOS_PER_MILLI;
+        let timestamp_secs = components.timestamp_ms / MS_PER_SECOND;
+        let timestamp_nanos = (components.timestamp_ms % MS_PER_SECOND) * NANOS_PER_MILLI;
 
         if let Some(datetime) =
             chrono::DateTime::from_timestamp(timestamp_secs as i64, timestamp_nanos as u32)


### PR DESCRIPTION
# Pull Request

## Description

Replace hardcoded numeric literals with named constants to improve code readability and maintainability across timestamp conversion logic. This refactoring introduces a centralized `MS_PER_SECOND` constant and applies consistent underscore formatting to numeric literals.

## Type of Change

Please select the relevant option:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 📝 Script template (new template or example for common use cases)
- [ ] 🔧 Maintenance (dependency updates, CI improvements, etc.)
- [ ] 🎨 Code style/formatting changes
- [x] ♻️ Refactoring (no functional changes)
- [ ] 🏗️ Infrastructure (CI/CD, deployment, build improvements)

## Related Issues

Closes #55

## Changes Made

Detailed list of changes:

- Added `MS_PER_SECOND` constant (1_000) in `src/ulid_engine.rs` for milliseconds-to-seconds conversions
- Replaced hardcoded `1000` with `crate::MS_PER_SECOND` in `src/commands/sort.rs` for timestamp conversion logic
- Replaced hardcoded `1000` and `1000.0` with `crate::MS_PER_SECOND` casts in `src/commands/time.rs` for both integer and float conversions
- Updated `DEFAULT_BATCH_SIZE` in `src/commands/stream.rs` to use underscore formatting (`1_000`) for consistency
- Updated timestamp reconstruction logic in `src/ulid_engine.rs` to use the new constant
- Updated test assertions to use the constant instead of magic numbers

## Testing

### Test Coverage

- [ ] New tests added for new functionality
- [x] Existing tests updated as needed
- [x] All tests pass locally
- [x] Manual testing completed

### Testing Instructions

Describe how reviewers can test these changes:

1. Run `cargo test` to verify all existing tests pass
2. Run `cargo clippy` to ensure no new warnings are introduced
3. Verify ULID time-related commands work correctly (e.g., `ulid time`, `ulid sort`)

### Test Results

```bash
cargo test
cargo clippy
cargo fmt --check
```

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement (provide benchmarks)
- [ ] Performance regression (justify why)
- [ ] Performance impact unknown/needs measurement

## Security Considerations

- [x] No security implications
- [ ] Security improvement
- [ ] Potential security concern (describe below)

## Breaking Changes

N/A - This is a pure refactoring with no functional or API changes.

## Documentation

- [x] Code comments updated
- [ ] README.md updated
- [ ] CHANGELOG.md updated
- [ ] API documentation updated
- [ ] Examples updated

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] No new warnings introduced

### Testing & Validation

- [x] All tests pass (`cargo test`)
- [x] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [ ] Security audit passes (`cargo audit`)
- [ ] Supply chain checks pass (`cargo deny check`)

### Documentation & Communication

- [x] Changes are documented
- [x] Commit messages follow conventional format
- [x] PR title is descriptive
- [ ] Any necessary migration guides created

### Dependencies & Compatibility

- [x] No unnecessary dependencies added
- [x] Minimum supported Rust version maintained
- [x] Nushell compatibility maintained
- [x] Cross-platform compatibility verified

## Additional Notes

This refactoring improves code maintainability by:
- Making the intent of numeric values explicit (e.g., `MS_PER_SECOND` clearly indicates milliseconds-to-seconds conversion)
- Centralizing time conversion constants in `ulid_engine.rs` alongside the existing `NANOS_PER_MILLI` constant
- Ensuring consistent numeric literal formatting with underscores for readability