### PR TITLE
chore(config): add claude worktrees and vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ plugin_registry.msgpack
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/worktrees
 
+# VSCode
 .vscode/
-


### PR DESCRIPTION
# Pull Request

## Description

Updates `.gitignore` to exclude Claude Code worktrees directory and adds a proper section header for VSCode settings. This ensures that Claude AI's worktree directories and VSCode workspace files are not accidentally committed to the repository.

## Type of Change

- [x] 🔧 Maintenance (dependency updates, CI improvements, etc.)

## Related Issues

N/A

## Changes Made

- Added `.claude/worktrees` to `.gitignore` to prevent Claude Code worktree directories from being tracked
- Added a `# VSCode` comment header above the existing `.vscode/` entry for better organization
- Removed trailing blank line at end of file

## Testing

### Test Coverage

- [ ] New tests added for new functionality
- [ ] Existing tests updated as needed
- [x] All tests pass locally
- [x] Manual testing completed

### Testing Instructions

1. Clone the repository
2. Verify that `.claude/worktrees` directories are ignored by git
3. Verify that `.vscode/` directories are still ignored by git

### Test Results

```bash
# No functional code changes; gitignore-only modification
cargo test
cargo clippy
```

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None.

## Documentation

- [x] Code comments updated

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] No new warnings introduced

### Testing & Validation

- [x] All tests pass (`cargo test`)
- [x] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Security audit passes (`cargo audit`)
- [x] Supply chain checks pass (`cargo deny check`)

### Documentation & Communication

- [x] Changes are documented
- [x] Commit messages follow conventional format
- [x] PR title is descriptive
- [ ] Any necessary migration guides created

### Dependencies & Compatibility

- [x] No unnecessary dependencies added
- [x] Minimum supported Rust version maintained
- [x] Nushell compatibility maintained
- [x] Cross-platform compatibility verified

## Additional Notes

This is a housekeeping change to keep Claude Code worktree directories and VSCode workspace configuration out of version control. The `.claude/settings.local.json` entry was already present; this adds the companion `.claude/worktrees` pattern that Claude Code creates when using its worktree feature.