### PR TITLE
docs(docs): add guidance on checking for existing constants before defining new ones

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -459,8 +459,13 @@ Literals that do **not** need extraction:
 - **Known-safe constructor arguments** — `FixedOffset::east_opt(0)` (covered by STYLE-0001).
 - **Test assertions** — `assert_eq!(result.len(), 3)` where the value is local to the test.
 
+Before defining a new constant, check whether one already exists for the same value — reuse it
+rather than introducing a duplicate. Domain-wide constants (e.g., `ULID_STRING_LENGTH`,
+`MS_PER_SECOND`) live as `pub const` in `ulid_engine.rs`; grep there first.
+
 Place constants at the narrowest useful scope: module-level `const` if used across functions in
-the same module, crate-level if shared across modules, or function-local `const` if truly local.
+the same module, crate-level `pub const` in `ulid_engine.rs` if shared across modules, or
+function-local `const` if truly local.
 
 ### Motivation
 


### PR DESCRIPTION
# Pull Request

## Description

Adds guidance to the Style Guide (STYLE-0010) instructing developers to check for existing constants before defining new ones. The new text directs contributors to grep `ulid_engine.rs` for domain-wide constants (e.g., `ULID_STRING_LENGTH`, `MS_PER_SECOND`) and reuse them rather than introducing duplicates. It also clarifies the placement guidance for crate-level constants, explicitly naming `ulid_engine.rs` as the canonical home for `pub const` values shared across modules.

## Type of Change

- [x] 📚 Documentation update (improvements or corrections to documentation)

## Related Issues

Closes #77

## Changes Made

- Added a new paragraph in `docs/STYLE_GUIDE.md` (STYLE-0010 section) instructing developers to search for existing constants before defining new ones, with `ulid_engine.rs` called out as the canonical location for domain-wide `pub const` values.
- Updated the constant placement guidance to replace the generic "crate-level if shared across modules" wording with the more specific "crate-level `pub const` in `ulid_engine.rs` if shared across modules", making the expected location explicit.

## Testing

### Test Coverage

- [ ] New tests added for new functionality
- [ ] Existing tests updated as needed
- [x] All tests pass locally
- [x] Manual testing completed

### Testing Instructions

This is a documentation-only change. Review the updated `docs/STYLE_GUIDE.md` to verify:

1. Open `docs/STYLE_GUIDE.md` and navigate to STYLE-0010.
2. Confirm the new paragraph about checking for existing constants appears before the placement rules.
3. Confirm the placement rule now explicitly references `ulid_engine.rs` for crate-level `pub const` values.

### Test Results

```bash
cargo test
cargo clippy
cargo audit
```

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security implications

## Breaking Changes

None. This is a documentation-only update with no code changes.

## Documentation

- [x] Code comments updated
- [ ] README.md updated
- [ ] CHANGELOG.md updated
- [ ] API documentation updated
- [ ] Examples updated

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] No new warnings introduced

### Testing & Validation

- [x] All tests pass (`cargo test`)
- [x] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Security audit passes (`cargo audit`)
- [x] Supply chain checks pass (`cargo deny check`)

### Documentation & Communication

- [x] Changes are documented
- [x] Commit messages follow conventional format
- [x] PR title is descriptive
- [ ] Any necessary migration guides created

### Dependencies & Compatibility

- [x] No unnecessary dependencies added
- [x] Minimum supported Rust version maintained
- [x] Nushell compatibility maintained
- [x] Cross-platform compatibility verified

## Additional Notes

This change is part of the ongoing effort to flesh out STYLE-0010 (extract magic values into named constants). The new guidance prevents accidental duplication of well-known constants such as `ULID_STRING_LENGTH` and `MS_PER_SECOND`, which are already defined in `ulid_engine.rs` and are intended to be the single source of truth across the crate.

---

**For Maintainers:**

- [ ] Labels applied
- [ ] Milestone assigned (if applicable)
- [ ] Security review completed (if needed)
- [ ] Performance review completed (if needed)
- [ ] Breaking change process followed (if applicable)