### PR TITLE
docs(docs,config): add ADR-0002 for supply chain security via cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -61,7 +61,8 @@ highlight = "all"
 allow = []
 # List of crates to deny
 deny = [
-    # Deny crates with known security issues
+    # openssl brings in C bindings with a complex build matrix and has historically
+    # carried security advisories; the project prefers pure-Rust TLS implementations.
     { name = "openssl", version = "*" },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -25,3 +25,4 @@ by Michael Nygard.
 |--------------------------|-------------|------------|----------------------------------------------------|
 | [ADR-0000](adr-0000.md)  | ✅ Accepted | 2026-02-10 | Use Architecture Decision Records                  |
 | [ADR-0001](adr-0001.md)  | 🟡 Proposed | 2026-03-01 | Conventional Commits with Project-Specific Scopes  |
+| [ADR-0002](adr-0002.md)  | ✅ Accepted | 2026-03-01 | Supply Chain Security via cargo-deny               |

--- a/docs/adrs/adr-0002.md
+++ b/docs/adrs/adr-0002.md
@@ -1,0 +1,90 @@
+# ADR-0002: Supply Chain Security via cargo-deny
+
+## Status
+
+✅ Accepted
+
+## Context
+
+nu_plugin_nw_ulid is a Nushell plugin that ships compiled binaries across multiple platforms. Its
+dependency tree is shaped by both its own direct dependencies and a large set of transitive
+dependencies pulled in through the Nushell plugin SDK. Without automated controls, it is easy
+for problematic dependencies to enter the build — whether through incompatible licences, known
+vulnerabilities, or untrusted sources.
+
+The project builds for five platform targets:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-unknown-linux-gnu`
+- `x86_64-pc-windows-msvc`
+- `x86_64-apple-darwin`
+- `aarch64-apple-darwin`
+
+Each target can pull in platform-specific dependencies, so supply chain checks must cover all of
+them.
+
+## Decision
+
+We will use [cargo-deny](https://embarkstudios.github.io/cargo-deny/) to enforce supply chain
+security policies. Configuration lives in `deny.toml` at the repository root and covers the
+following areas. Item-level rationale (why a specific crate is banned, why a specific advisory
+is ignored) is documented as inline comments in `deny.toml` itself, co-located with the setting
+it explains.
+
+### Advisories
+
+The RustSec advisory database is checked on every run. Advisories for transitive dependencies
+that the project cannot control are documented as explicit exceptions with inline comments
+explaining why they are safe to ignore:
+
+- `RUSTSEC-2024-0436` — the `paste` crate is unmaintained but remains a transitive dependency
+  of the Nushell ecosystem. It poses no runtime security risk.
+
+Exceptions are reviewed whenever dependencies are upgraded. Stale exceptions are removed once
+the affected dependency leaves the tree — for example, the `proc-macro-error` advisory was
+dropped after Nushell 0.109.1 removed that transitive dependency.
+
+### Licences
+
+Only permissive licences are allowed. The authoritative allowlist is maintained in the
+`[licenses].allow` array in `deny.toml`, which currently includes MIT, Apache-2.0, BSD variants,
+ISC, MPL-2.0, Unicode-3.0, CC-PDDC, and Zlib. Any dependency whose detected licence is not in
+the allowlist will cause a build failure. No copyleft exceptions are currently granted beyond
+MPL-2.0 (required by `option-ext`, a Nushell transitive dependency).
+
+### Bans
+
+The `openssl` crate is explicitly banned — the rationale is documented in the inline comment in
+`deny.toml`.
+
+Duplicate crate versions are temporarily allowed (`multiple-versions = "allow"`) because the
+Nushell ecosystem currently pulls in conflicting transitive dependency versions (first observed
+with Nushell 0.95.0). This will be tightened to `"warn"` once the ecosystem stabilises.
+
+### Sources
+
+Only the official crates.io registry (`https://github.com/rust-lang/crates.io-index`) is in the
+allow list. Crates from unknown registries or git repositories trigger a warning.
+
+### Workflow integration
+
+Two Makefile targets expose the checks:
+
+- `make audit` — runs `cargo audit` for known vulnerability scanning.
+- `make deny` — runs `cargo deny check` for the full policy suite (advisories, licences, bans,
+  sources).
+
+Both targets are composed into `make ci`, which is the full CI simulation pipeline.
+
+## Consequences
+
+- Every dependency addition or upgrade is automatically checked against licence, advisory, ban,
+  and source policies before it can be merged.
+- The project maintains a clear, auditable record of which licences are permitted and why
+  specific advisories are exempted.
+- Maintainers must update `deny.toml` when new licences or advisories need to be accommodated,
+  adding a small amount of ongoing maintenance overhead.
+- The temporary leniency on duplicate crate versions means some dependency bloat goes undetected
+  until the Nushell ecosystem resolves its version conflicts.
+- Cross-platform coverage ensures that platform-specific dependencies (e.g., Windows-only crates)
+  are subject to the same supply chain policies as the rest of the tree.


### PR DESCRIPTION
# Pull Request

## Description

Introduces ADR-0002 documenting the architectural decision to use `cargo-deny` for supply chain security enforcement across all five supported build targets. This ADR formalises the policies already in place via `deny.toml` and improves the inline comment explaining the `openssl` ban.

## Type of Change

- [x] 📚 Documentation update (improvements or corrections to documentation)

## Related Issues

Closes #82

## Changes Made

- **Added `docs/adrs/adr-0002.md`**: New ADR covering the full `cargo-deny` policy scope:
  - RustSec advisory checks with documented exceptions (e.g. `RUSTSEC-2024-0436` for the unmaintained `paste` crate)
  - Permissive-only licence allowlist (MIT, Apache-2.0, BSD variants, ISC, MPL-2.0, Unicode-3.0, CC-PDDC, Zlib)
  - Explicit ban on the `openssl` crate (C bindings, complex build matrix, historical security advisories)
  - Temporary allowance of duplicate crate versions pending Nushell ecosystem stabilisation
  - crates.io-only source restriction
  - Documents `make audit` and `make deny` CI targets
- **Updated `docs/adrs/README.md`**: Registered ADR-0002 in the ADR index table with status ✅ Accepted and date 2026-03-01
- **Updated `deny.toml`**: Improved the inline comment for the `openssl` ban to clearly explain the rationale (C bindings, complex build matrix, historical security advisories, preference for pure-Rust TLS)

## Testing

### Test Coverage

- [ ] New tests added for new functionality
- [ ] Existing tests updated as needed
- [x] All tests pass locally
- [x] Manual testing completed

### Testing Instructions

1. Review `docs/adrs/adr-0002.md` for accuracy and completeness against `deny.toml`
2. Verify the ADR index in `docs/adrs/README.md` correctly links to `adr-0002.md`
3. Confirm the updated `deny.toml` comment accurately reflects the rationale for banning `openssl`
4. Run `make deny` to confirm `cargo deny check` passes with the updated configuration

### Test Results

```bash
make deny   # cargo deny check — all policies pass
make audit  # cargo audit — no unaddressed advisories
```

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] Security improvement

This PR formalises the supply chain security policy that `cargo-deny` enforces on every build. By documenting the policy decisions in an ADR, maintainers have a clear, auditable record of which licences are permitted, why specific advisories are exempted, and why `openssl` is banned. The improved inline comment in `deny.toml` makes it immediately clear to contributors why the ban exists without needing to consult external documentation.

## Breaking Changes

None. This is a documentation-only change with a minor comment improvement in `deny.toml`.

## Documentation

- [x] Code comments updated (`deny.toml` openssl ban comment improved)
- [ ] README.md updated
- [ ] CHANGELOG.md updated
- [ ] API documentation updated
- [ ] Examples updated

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Code is properly commented, particularly in hard-to-understand areas
- [x] No new warnings introduced

### Testing & Validation

- [x] All tests pass (`cargo test`)
- [x] No linting errors (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] Security audit passes (`cargo audit`)
- [x] Supply chain checks pass (`cargo deny check`)

### Documentation & Communication

- [x] Changes are documented
- [x] Commit messages follow conventional format
- [x] PR title is descriptive
- [ ] Any necessary migration guides created

### Dependencies & Compatibility

- [x] No unnecessary dependencies added
- [x] Minimum supported Rust version maintained
- [x] Nushell compatibility maintained
- [x] Cross-platform compatibility verified

## Additional Notes

The ADR explicitly acknowledges the temporary leniency on duplicate crate versions (`multiple-versions = "allow"`) and records the intent to tighten this to `"warn"` once the Nushell ecosystem resolves its transitive dependency version conflicts. This provides a clear signal for future maintainers to revisit the setting after Nushell ecosystem stabilisation.

Cross-platform coverage is called out in the ADR because the five supported build targets (x86_64-linux, aarch64-linux, x86_64-windows, x86_64-darwin, aarch64-darwin) can each pull in platform-specific dependencies, making it important that `cargo deny check` runs against all targets in CI.

---

**For Maintainers:**

- [ ] Labels applied
- [ ] Milestone assigned (if applicable)
- [x] Security review completed (if needed)
- [ ] Performance review completed (if needed)
- [ ] Breaking change process followed (if applicable)